### PR TITLE
Fixed some swiftlint issues

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,5 @@
 line_length:
   warning: 300
   error: 400
+included:
+  - "AutoMate"

--- a/AutoMate/Models/HardwareKeyboard.swift
+++ b/AutoMate/Models/HardwareKeyboard.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable identifier_name type_body_length trailing_comma file_length line_length
+// swiftlint:disable identifier_name
 
 /// Enumeration describing available hardware keyboards in the system.
 public enum HardwareKeyboard: String, LaunchArgumentValue {

--- a/AutoMate/Models/HealthAlerts.swift
+++ b/AutoMate/Models/HealthAlerts.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable identifier_name type_body_length trailing_comma file_length line_length
+// swiftlint:disable identifier_name
 /// Represents possible health service messages and label values on buttons.
 
 import XCTest

--- a/AutoMate/Models/LocationAlerts.swift
+++ b/AutoMate/Models/LocationAlerts.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable identifier_name type_body_length trailing_comma file_length line_length
+// swiftlint:disable identifier_name
 /// Represents possible location service messages and label values on buttons.
 
 import XCTest

--- a/AutoMate/Models/ServiceRequestAlerts.swift
+++ b/AutoMate/Models/ServiceRequestAlerts.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable identifier_name type_body_length trailing_comma file_length line_length
+// swiftlint:disable file_length
 /// Represents possible system service messages and label values on buttons.
 
 import XCTest

--- a/AutoMate/Models/SoftwareKeyboard.swift
+++ b/AutoMate/Models/SoftwareKeyboard.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable identifier_name type_body_length trailing_comma file_length line_length
+// swiftlint:disable identifier_name
 
 /// Enumeration describing available software keyboards in the system.
 public enum SoftwareKeyboard: String, LaunchArgumentValue {

--- a/AutoMate/Models/SystemCountry.swift
+++ b/AutoMate/Models/SystemCountry.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable identifier_name type_body_length trailing_comma file_length line_length
+// swiftlint:disable identifier_name type_body_length file_length
 
 /// Enumeration describing available country codes in the system.
 public enum SystemCountry: String {

--- a/AutoMate/Models/SystemLanguage.swift
+++ b/AutoMate/Models/SystemLanguage.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable identifier_name type_body_length trailing_comma file_length line_length
+// swiftlint:disable identifier_name file_length type_body_length
 
 /// Enumeration describing available languages in the system.
 public enum SystemLanguage: String, LaunchArgumentValue {

--- a/AutoMateExample/.swiftlint.yml
+++ b/AutoMateExample/.swiftlint.yml
@@ -2,3 +2,5 @@ disabled_rules:
   - line_length
   - type_name
   - file_length
+excluded:
+  - "Pods"

--- a/AutoMateTests/LaunchOptionsSetTests.swift
+++ b/AutoMateTests/LaunchOptionsSetTests.swift
@@ -74,7 +74,7 @@ class LaunchOptionsSetTests: XCTestCase {
     func testDisjointSetsIntersectionToBeEmpty() {
         let set1: LaunchOptionsSet = [option]
         let set2: LaunchOptionsSet = [option1]
-        XCTAssertTrue(set1.intersection(set2).isEmpty)
+        XCTAssertTrue(set1.isDisjoint(with: set2))
     }
 
     func testIntersectionOfSetsWithCommonElement() {


### PR DESCRIPTION
Fixed some swiftlint issues being caught by using version 0.23.1 and disabled swiftlint from being run on the Pods directory in the AutoMateExample directory.

Most of the issues were due to the `superfluous_disable_command`.  I removed the rules which did not need to be disabled.